### PR TITLE
fNpa is updated after Particle is removed from array

### DIFF
--- a/base/src/UEvent.cxx
+++ b/base/src/UEvent.cxx
@@ -234,6 +234,7 @@ void UEvent::RemoveAt(Int_t i)
   // Array is automaticaly compressed afterwards, mind the indexing
   fParticles->RemoveAt(i);
   fParticles->Compress();
+  fNpa -= 1;
 }
 //--------------------------------------------------------------------
 


### PR DESCRIPTION
After a Particle is removed with UEvent::RemoveAt() the fNpa was not updated, resulting in a mismatch between fNpa and fParticles->GetEntries(). This results in empty entries when loops over fNpa.

Perhaps in general fNpa should be updated from fParticles->GetEntries() after a file is loaded.